### PR TITLE
Added Hello_CircuitPlayground examples

### DIFF
--- a/examples/Hello_CircuitPlayground/Hello_Accelerometer/Hello_Accelerometer.ino
+++ b/examples/Hello_CircuitPlayground/Hello_Accelerometer/Hello_Accelerometer.ino
@@ -1,0 +1,23 @@
+#include <Adafruit_CircuitPlayground.h>
+
+float X, Y, Z;
+
+void setup() {
+  Serial.begin(9600);
+  CircuitPlayground.begin();
+}
+
+void loop() {
+  X = CircuitPlayground.motionX();
+  Y = CircuitPlayground.motionY();
+  Z = CircuitPlayground.motionZ();
+
+  Serial.print("X: ");
+  Serial.print(X);
+  Serial.print("  Y: ");
+  Serial.print(Y);
+  Serial.print("  Z: ");
+  Serial.println(Z);
+
+  delay(1000);
+}

--- a/examples/Hello_CircuitPlayground/Hello_Blink/Hello_Blink.ino
+++ b/examples/Hello_CircuitPlayground/Hello_Blink/Hello_Blink.ino
@@ -1,0 +1,12 @@
+#include <Adafruit_CircuitPlayground.h>
+
+void setup() {
+  CircuitPlayground.begin();
+}
+
+void loop() {
+  CircuitPlayground.redLED(HIGH);
+  delay(500);
+  CircuitPlayground.redLED(LOW);
+  delay(500);
+}

--- a/examples/Hello_CircuitPlayground/Hello_Buttons/Hello_Buttons.ino
+++ b/examples/Hello_CircuitPlayground/Hello_Buttons/Hello_Buttons.ino
@@ -1,0 +1,30 @@
+#include <Adafruit_CircuitPlayground.h>
+
+bool leftButtonPressed;
+bool rightButtonPressed;
+
+void setup() {
+  Serial.begin(9600);
+  CircuitPlayground.begin();
+}
+
+void loop() {
+  leftButtonPressed = CircuitPlayground.leftButton();
+  rightButtonPressed = CircuitPlayground.rightButton();
+  
+  Serial.print("Left Button: ");
+  if (leftButtonPressed) {
+    Serial.print("DOWN");
+  } else {
+    Serial.print("  UP");
+  }
+  Serial.print("   Right Button: ");
+  if (rightButtonPressed) {
+    Serial.print("DOWN");
+  } else {
+    Serial.print("  UP");    
+  }
+  Serial.println();
+  
+  delay(1000);
+}

--- a/examples/Hello_CircuitPlayground/Hello_LightSensor/Hello_LightSensor.ino
+++ b/examples/Hello_CircuitPlayground/Hello_LightSensor/Hello_LightSensor.ino
@@ -1,0 +1,17 @@
+#include <Adafruit_CircuitPlayground.h>
+
+int value;
+
+void setup() {
+  Serial.begin(9600);
+  CircuitPlayground.begin();
+}
+
+void loop() {
+  value = CircuitPlayground.lightSensor();
+  
+  Serial.print("Light Sensor: ");
+  Serial.println(value);
+  
+  delay(1000);
+}

--- a/examples/Hello_CircuitPlayground/Hello_NeoPixels/Hello_NeoPixels.ino
+++ b/examples/Hello_CircuitPlayground/Hello_NeoPixels/Hello_NeoPixels.ino
@@ -1,0 +1,25 @@
+#include <Adafruit_CircuitPlayground.h>
+
+void setup() {
+  CircuitPlayground.begin();
+}
+
+void loop() {
+  CircuitPlayground.clearPixels();
+
+  delay(500);
+
+  CircuitPlayground.setPixelColor(0, 255,   0,   0);
+  CircuitPlayground.setPixelColor(1, 128, 128,   0);
+  CircuitPlayground.setPixelColor(2,   0, 255,   0);
+  CircuitPlayground.setPixelColor(3,   0, 128, 128);
+  CircuitPlayground.setPixelColor(4,   0,   0, 255);
+  
+  CircuitPlayground.setPixelColor(5, 0xFF0000);
+  CircuitPlayground.setPixelColor(6, 0x808000);
+  CircuitPlayground.setPixelColor(7, 0x00FF00);
+  CircuitPlayground.setPixelColor(8, 0x008080);
+  CircuitPlayground.setPixelColor(9, 0x0000FF);
+ 
+  delay(5000);
+}

--- a/examples/Hello_CircuitPlayground/Hello_SlideSwitch/Hello_SlideSwitch.ino
+++ b/examples/Hello_CircuitPlayground/Hello_SlideSwitch/Hello_SlideSwitch.ino
@@ -1,0 +1,22 @@
+#include <Adafruit_CircuitPlayground.h>
+
+bool slideSwitch;
+
+void setup() {
+  Serial.begin(9600);
+  CircuitPlayground.begin();
+}
+
+void loop() {
+  slideSwitch = CircuitPlayground.slideSwitch();
+  
+  Serial.print("Slide Switch: ");
+  if (slideSwitch) {
+    Serial.print("+");
+  } else {
+    Serial.print("-");
+  }
+  Serial.println();
+  
+  delay(1000);
+}

--- a/examples/Hello_CircuitPlayground/Hello_SoundSensor/Hello_SoundSensor.ino
+++ b/examples/Hello_CircuitPlayground/Hello_SoundSensor/Hello_SoundSensor.ino
@@ -1,0 +1,17 @@
+#include <Adafruit_CircuitPlayground.h>
+
+int value;
+
+void setup() {
+  Serial.begin(9600);
+  CircuitPlayground.begin();
+}
+
+void loop() {
+  value = CircuitPlayground.soundSensor();
+  
+  Serial.print("Sound Sensor: ");
+  Serial.println(value);
+  
+  delay(1000);
+}

--- a/examples/Hello_CircuitPlayground/Hello_Speaker/Hello_Speaker.ino
+++ b/examples/Hello_CircuitPlayground/Hello_Speaker/Hello_Speaker.ino
@@ -1,0 +1,10 @@
+#include <Adafruit_CircuitPlayground.h>
+
+void setup() {
+  CircuitPlayground.begin();
+}
+
+void loop() {
+  CircuitPlayground.playTone(500, 100);
+  delay(1000);
+}

--- a/examples/Hello_CircuitPlayground/Hello_Temperature/Hello_Temperature.ino
+++ b/examples/Hello_CircuitPlayground/Hello_Temperature/Hello_Temperature.ino
@@ -1,0 +1,20 @@
+#include <Adafruit_CircuitPlayground.h>
+
+float tempC, tempF;
+
+void setup() {
+  Serial.begin(9600);
+  CircuitPlayground.begin();
+}
+
+void loop() {
+  tempC = CircuitPlayground.temperature();
+  tempF = CircuitPlayground.temperatureF();
+
+  Serial.print("tempC: ");
+  Serial.print(tempC);
+  Serial.print("  tempF: ");
+  Serial.println(tempF);
+
+  delay(1000);
+}

--- a/examples/Hello_CircuitPlayground/README.md
+++ b/examples/Hello_CircuitPlayground/README.md
@@ -1,0 +1,84 @@
+# Hello Circuit Playground
+A set of very basic example sketches to demonstrate the various components
+of the [Circuit Playground](https://www.adafruit.com/products/3000).
+These sketches were tested and verified with:
+* Circuit Playground Developer Edition
+* Ubuntu 16.04 LTS
+* Arduino IDE 1.6.11
+* Adafruit AVR Boards 1.4.9
+* Adafruit Circuit Playground Library 1.6.1
+
+## Hello_Blink
+Blinks the little red LED next to the micro USB connector once per second.
+
+## Hello_SlideSwitch
+The position (+ or -) of the slide switch is sent to the serial monitor once
+per second.
+```
+Slide Switch: -
+Slide Switch: +
+Slide Switch: +
+```
+
+## Hello_Buttons
+The position (UP or DOWN) of the two push buttons are sent to the serial
+monitor once per second.
+```
+Left Button:   UP   Right Button:   UP
+Left Button: DOWN   Right Button:   UP
+Left Button:   UP   Right Button:   UP
+Left Button:   UP   Right Button: DOWN
+```
+
+## Hello_LightSensor
+The reading (0-1023) from the light sensor is sent to the serial monitor once
+per second.
+```
+Light Sensor: 962
+Light Sensor: 954
+Light Sensor: 275
+Light Sensor: 192
+Light Sensor: 688
+```
+
+## Hello_Temperature
+The temperature is sent to the serial monitor once per second.
+```
+tempC: 28.25  tempF: 83.02
+tempC: 29.71  tempF: 85.64
+tempC: 30.72  tempF: 87.30
+tempC: 31.85  tempF: 89.32
+```
+
+## Hello_Accelerometer
+The readings (in m/s<sup>2</sup>) from the 3 axes of the accelerometer are sent
+to the serial monitor once per second. (1G ~= 9.8 m/s<sup>2</sup>)
+```
+X: -0.33  Y: 2.41  Z: 9.40
+X: -1.25  Y: 4.20  Z: 1.86
+X: -7.95  Y: -3.50  Z: -2.47
+X: 0.11  Y: -8.38  Z: 2.25
+X: -2.28  Y: 2.73  Z: 9.10
+```
+
+## Hello_SoundSensor
+The reading (0-1023) from the sound sensor (microphone) is sent to the serial
+monitor once per second.
+```
+Sound Sensor: 339
+Sound Sensor: 339
+Sound Sensor: 1023
+Sound Sensor: 10
+Sound Sensor: 15
+Sound Sensor: 1023
+Sound Sensor: 336
+```
+
+## Hello_Speaker
+Plays a 500Hz tone for 0.1 seconds on the speaker, followed by 1 second of
+silence.
+
+## Hello_NeoPixels
+Clears all pixels for 0.5 seconds then displays colors on the fist 5 pixels
+using individual 8-bit values and the same colors on the next 5 pixels using
+24-bit values. After 5 seconds, this repeats.


### PR DESCRIPTION
No modifications, only additions. Added a set of very basic sketches to demonstrate the various components of the Circuit Playground. Each sketch only deals with one hardware component. Sketch names are Hello_ITEM, where ITEM is the hardware component being demonstrated.

Code comments left out to reduce clutter. Hopefully code is simple enough to be self evident.

All sketches have been placed in the folder /examples/Hello_CircuitPlayground/