### PR TITLE
Automagic disable of NeoPixel Code if FastLED is included first

### DIFF
--- a/Adafruit_CircuitPlayground.h
+++ b/Adafruit_CircuitPlayground.h
@@ -70,9 +70,9 @@
 
 class Adafruit_CircuitPlayground {
  public:
-#ifndef __INC_FASTSPI_LED2_H
   boolean begin(uint8_t brightness=20);
 
+#ifndef __INC_FASTSPI_LED2_H
   Adafruit_CPlay_NeoPixel strip;
 #endif
   Adafruit_CPlay_LIS3DH lis;
@@ -97,7 +97,7 @@ class Adafruit_CircuitPlayground {
   float motionY(void);
   float motionZ(void);
   void setAccelRange(lis3dh_range_t range) { lis.setRange(range); }
-  void setAccelTap(uint8_t c, uint8_t clickthresh) 
+  void setAccelTap(uint8_t c, uint8_t clickthresh)
     { lis.setClick(c, clickthresh, 10, 20, 255); }
   uint8_t getAccelTap(void) { return (lis.getClick() >> 8) & 0x3; }
 

--- a/Adafruit_CircuitPlayground.h
+++ b/Adafruit_CircuitPlayground.h
@@ -14,8 +14,9 @@
   You should have received a copy of the GNU Lesser General Public
   License along with DotStar.  If not, see <http://www.gnu.org/licenses/>.
   ------------------------------------------------------------------------*/
-
+#ifndef __INC_FASTSPI_LED2_H
 #include "utility/Adafruit_CPlay_NeoPixel.h"
+#endif
 #include "utility/Adafruit_CPlay_LIS3DH.h"
 #include "utility/Adafruit_CPlay_Mic.h"
 #include "utility/Adafruit_CPlay_Speaker.h"
@@ -30,7 +31,11 @@
 #endif
 
 #define CPLAY_REDLED 13
+
+#ifndef __INC_FASTSPI_LED2_H
 #define CPLAY_NEOPIXELPIN 17
+#endif
+
 #define CPLAY_SLIDESWITCHPIN 21
 #define CPLAY_LEFTBUTTON 4
 #define CPLAY_RIGHTBUTTON 19
@@ -65,9 +70,11 @@
 
 class Adafruit_CircuitPlayground {
  public:
+#ifndef __INC_FASTSPI_LED2_H
   boolean begin(uint8_t brightness=20);
 
   Adafruit_CPlay_NeoPixel strip;
+#endif
   Adafruit_CPlay_LIS3DH lis;
   Adafruit_CPlay_Mic mic;
   Adafruit_CPlay_Speaker speaker;
@@ -94,7 +101,7 @@ class Adafruit_CircuitPlayground {
     { lis.setClick(c, clickthresh, 10, 20, 255); }
   uint8_t getAccelTap(void) { return (lis.getClick() >> 8) & 0x3; }
 
-
+#ifndef __INC_FASTSPI_LED2_H
   // neopixels
   void clearPixels(void) { strip.clear(); strip.show(); }
   void setPixelColor(uint8_t p, uint32_t c) {strip.setPixelColor(p, c); strip.show();}
@@ -114,6 +121,7 @@ class Adafruit_CircuitPlayground {
     senseColor(red, green, blue);
     return ((uint32_t)red << 16) | ((uint32_t)green << 8) | blue;
   }
+#endif
 
  private:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # Fork of Adafruit_CircuitPlayground
 library for Circuit Playground board that will disable the neopixel portions if FastLED is included before it.
 
+### If this library is included before FastLED, you will have both available to use and possibly conflict in setting color, brightness, etc.
+
+## I created this fork because I perfer to use FastLED to control addressable leds.
+
 To use FastLED make sure the #include <FastLED.h> is before this library

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Fork of Adafruit_CircuitPlayground
+library for Circuit Playground board that will disable the neopixel portions if FastLED is included before it.
+
+To use FastLED make sure the #include <FastLED.h> is before this library


### PR DESCRIPTION
I added code that checks if FastLED was included before this library is included and excludes
the NeoPixel code if it is.

All changes are within Adafruit_CircuitPlayground.h, wrapping the NeoPixel code in #ifndef ... #endif

The README.md is for people that find my repository and choose to use it.
