### PR TITLE
changed playTone() to blocking

### DIFF
--- a/Adafruit_CircuitPlayground.cpp
+++ b/Adafruit_CircuitPlayground.cpp
@@ -76,8 +76,9 @@ boolean Adafruit_CircuitPlayground::rightButton(void) {
   return digitalRead(CPLAY_RIGHTBUTTON);
 }
 
-void Adafruit_CircuitPlayground::playTone(uint16_t freq, uint16_t time) {
+void Adafruit_CircuitPlayground::playTone(uint16_t freq, uint16_t time, boolean wait) {
   tone(CPLAY_BUZZER, freq, time);
+  if (wait) delay(time);
 }
 
 uint16_t Adafruit_CircuitPlayground::lightSensor(void) {

--- a/Adafruit_CircuitPlayground.h
+++ b/Adafruit_CircuitPlayground.h
@@ -75,7 +75,7 @@ class Adafruit_CircuitPlayground {
 
   boolean slideSwitch(void);
   void redLED(boolean v);
-  void playTone(uint16_t freq, uint16_t time);
+  void playTone(uint16_t freq, uint16_t time, boolean wait=true);
   boolean leftButton(void);
   boolean rightButton(void);
   uint16_t lightSensor(void);


### PR DESCRIPTION
Ref. Issue #17.

Changes `playTone()` function to blocking by default. **NOTE**: this changes current behaviour. Added a boolean parameter to `playTone()` to control blocking and set default to true (block). The following code will now play the two tones for 1 second each.
```C++
CircuitPlayground.playTone(500, 1000);
CircuitPlayground.playTone(800, 1000);
```
To restore previous behaviour, must turn blocking off by passing in `false`:
```C++
CircuitPlayground.playTone(500, 1000, false);
delay(1000);
CircuitPlayground.playTone(800, 1000, false);
delay(1000);
```