### PR TITLE
Infrared NeoPixel sketch that sends and receives patterns

### DIFF
--- a/examples/Infrared_NeoPixel_SendRecv/Infrared_NeoPixel_SendRecv.ino
+++ b/examples/Infrared_NeoPixel_SendRecv/Infrared_NeoPixel_SendRecv.ino
@@ -1,0 +1,187 @@
+/* Infrared_NeoPixel.ino Example sketch for IRLib2 and Circuit Playground Express
+   Illustrates how to change NeoPixel patterns and colors using
+   an IR remote. Programmed to use IR codes for Adafruit mini remote
+   https://www.adafruit.com/product/389
+   Press the following keys on the remote:
+    vol-          decrease brightness
+    vol+          increase brightness
+    right arrow   rotate clockwise   
+    left arrow    rotate counterclockwise
+    up arrow      rotate faster
+    down arrow    rotate slower
+    0             rainbow pattern
+    1             candy cane pattern
+    2             one red pixel
+    3             decreased solid colors
+    4             increase solid colors
+ */
+#include <Adafruit_CircuitPlayground.h>
+#include "adafruit_mini_codes.h"
+#define IR_BITS 32
+
+#if !defined(ARDUINO_SAMD_CIRCUITPLAYGROUND_EXPRESS)
+  #error "Infrared support is only for the Circuit Playground Express, it doesn't work with the Classic version"
+#endif
+
+
+//Pattern numbers
+#define RAINBOW    0
+#define CANDY_CANE 1
+#define JUST_ONE   2
+#define MONOCHROME 3
+
+uint8_t i,j,Phase, Pattern;
+int8_t Direction, Mono;
+int16_t Bright, Speed;
+int8_t whichpattern = 0; // can I init values in the declaration?
+
+void Show_Pattern(void) {
+  CircuitPlayground.setBrightness(Bright);
+  for(i=0;i<11;i++) {
+    j= (20+i+Phase*Direction) % 10;
+    switch (Pattern) {
+      case RAINBOW:
+        CircuitPlayground.setPixelColor(j, CircuitPlayground.colorWheel(25*i));  
+        break;
+      case CANDY_CANE: 
+        if((i % 5)<2) {
+          CircuitPlayground.setPixelColor(j, 255,0,0);
+        } else  {
+          CircuitPlayground.setPixelColor(j, 255,255,255);
+        }
+        break;
+      case JUST_ONE:
+        if(i<2) {
+          CircuitPlayground.setPixelColor(j, 255,0,0);
+        } else  {
+          CircuitPlayground.setPixelColor(j, 0,0,0);
+        }
+        break;
+      case MONOCHROME:
+        CircuitPlayground.setPixelColor(i, CircuitPlayground.colorWheel(25*Mono));  
+        break;
+    }
+  }
+}
+
+void setup() {
+  CircuitPlayground.begin();
+  Serial.begin(9600);
+  CircuitPlayground.irReceiver.enableIRIn(); // Start the receiver
+  Bright=8;  Phase=0;  Pattern=2;  Direction=1;  Speed=300;
+  Mono=0;  
+}
+
+void loop() {
+  // to test swapping between send and recv inside the loop,
+  // first we send the 'next' pattern via IR
+  switch (whichpattern) {
+    case 0:
+      CircuitPlayground.irSend.send(NEC, ADAF_MINI_0_10_PLUS, IR_BITS); // what should IR_bits be set to??
+      break;
+    case 1:
+      CircuitPlayground.irSend.send(NEC, ADAF_MINI_1, IR_BITS); // what should IR_bits be set to??
+      break;
+    case 2:
+      CircuitPlayground.irSend.send(NEC, ADAF_MINI_2, IR_BITS); // what should IR_bits be set to??
+      break;
+    case 3:
+      CircuitPlayground.irSend.send(NEC, ADAF_MINI_3, IR_BITS); // what should IR_bits be set to??
+      break;
+    default:
+      whichpattern = -1;
+  }
+    CircuitPlayground.irReceiver.enableIRIn(); // Start the receiver
+
+  whichpattern++; // increment the pattern choice, then send the matching IR code
+  
+  // First up, display whatever neopixel patterm we're doing
+  Show_Pattern();
+
+  // a small pause
+  delay(Speed);
+
+  // go to next phase next time
+  Phase++;
+  if (Phase >= 10) {
+   Phase = 0;
+  }
+
+  // Did we get any infrared signals?
+  if (! CircuitPlayground.irReceiver.getResults()) {
+    return;
+  }
+
+  // Did we get any decodable messages?
+  if (! CircuitPlayground.irDecoder.decode()) {
+    CircuitPlayground.irReceiver.enableIRIn(); // Restart receiver  
+    return;
+  }
+
+  // We can print out the message if we want...
+  CircuitPlayground.irDecoder.dumpResults(false);
+
+  // Did we get any NEC remote messages?
+  if (! CircuitPlayground.irDecoder.protocolNum == NEC) {
+    CircuitPlayground.irReceiver.enableIRIn(); // Restart receiver  
+    return;
+  }
+
+  // What message did we get?
+  switch(CircuitPlayground.irDecoder.value) {
+  case ADAF_MINI_0_10_PLUS: 
+    Serial.println("Rainbow mode!");
+    Pattern = RAINBOW; 
+    break;
+  case ADAF_MINI_1: 
+    Serial.println("Candy Cane mode!");
+    Pattern = CANDY_CANE;  
+    break;
+  case ADAF_MINI_2: 
+    Serial.println("Just One mode!");
+    Pattern = JUST_ONE;  
+    break;
+  case ADAF_MINI_3: 
+    Serial.println("Monochrome mode, less");
+    Pattern = MONOCHROME; 
+    Mono--;
+    if (Mono < 0) {
+      Mono = 9;
+    }
+    break;
+  case ADAF_MINI_4: 
+    Serial.println("Monochrome mode, more");
+    Pattern = MONOCHROME;
+    Mono++;
+    if (Mono > 9) {
+      Mono = 0;
+    }
+    break;
+  case ADAF_MINI_LEFT_ARROW: 
+    Serial.println("Counter-Clockwise");
+    Direction = 1;
+    break;
+  case ADAF_MINI_RIGHT_ARROW: 
+    Serial.println("Clockwise");
+    Direction = -1;
+    break;
+  case ADAF_MINI_VOLUME_UP: 
+    Serial.println("Brighter");
+    Bright = min(255, Bright+2); 
+    break;
+  case ADAF_MINI_VOLUME_DOWN: 
+    Serial.println("Dimmer");
+    Bright = max(0, Bright-2); 
+    break;
+  case ADAF_MINI_UP_ARROW: 
+    Serial.println("Faster");
+    Speed = max(50, Speed-50); 
+    break;
+  case ADAF_MINI_DOWN_ARROW: 
+    Serial.println("Slower");
+    Speed = min(2000, Speed+50); 
+    break;
+  }
+  //Restart receiver
+  CircuitPlayground.irReceiver.enableIRIn();      
+}

--- a/examples/Infrared_NeoPixel_SendRecv/adafruit_mini_codes.h
+++ b/examples/Infrared_NeoPixel_SendRecv/adafruit_mini_codes.h
@@ -1,0 +1,28 @@
+/*
+  IR codes for Adafruit mini remote
+  https://www.adafruit.com/product/389
+  Uses NEC protocol
+  */
+
+#define ADAF_MINI_VOLUME_DOWN	0xfd00ff
+#define ADAF_MINI_PLAY_PAUSE	0xfd807f
+#define ADAF_MINI_VOLUME_UP	0xfd40bf
+#define ADAF_MINI_SETUP	0xfd20df
+#define ADAF_MINI_UP_ARROW	0xfda05f
+#define ADAF_MINI_STOP_MODE	0xfd609f
+#define ADAF_MINI_LEFT_ARROW	0xfd10ef
+#define ADAF_MINI_ENTER_SAVE	0xfd906f
+#define ADAF_MINI_RIGHT_ARROW	0xfd50af
+#define ADAF_MINI_0_10_PLUS	0xfd30cf
+#define ADAF_MINI_DOWN_ARROW	0xfdb04f
+#define ADAF_MINI_REPEAT	0xfd708f
+#define ADAF_MINI_1	0xfd08f7
+#define ADAF_MINI_2	0xfd8877
+#define ADAF_MINI_3	0xfd48b7
+#define ADAF_MINI_4	0xfd28d7
+#define ADAF_MINI_5	0xfda857
+#define ADAF_MINI_6	0xfd6897
+#define ADAF_MINI_7	0xfd18e7
+#define ADAF_MINI_8	0xfd9867
+#define ADAF_MINI_9	0xfd58a7
+


### PR DESCRIPTION
This example is a minor modification to the Infrared_NeoPixel sketch that adds sending of NeoPixel patterns, to demonstrate how two Circuit Playground Express boards can talk to each other.

This was tested on two boards, seems to work.