### PR TITLE
Fix redLed()

### DIFF
--- a/Adafruit_CircuitPlayground.cpp
+++ b/Adafruit_CircuitPlayground.cpp
@@ -61,8 +61,6 @@ bool Adafruit_CircuitPlayground::begin(uint8_t brightness) {
   lis = Adafruit_CPlay_LIS3DH(CPLAY_LIS3DH_CS);
   mic = Adafruit_CPlay_Mic();
 
-  speaker.begin();
-
   strip.begin();
   strip.show(); // Initialize all pixels to 'off'
   strip.setBrightness(brightness);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit Circuit Playground
-version=1.8.3
+version=1.8.4
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=All in one library to control Adafruit's Circuit Playground board.


### PR DESCRIPTION
Possible fix for #40

Tested with a CPC and a CPX. Following blinks red LED on D13 10 times then plays a tone for a second, and repeats.
```cpp
#include <Adafruit_CircuitPlayground.h>

void setup() {
  CircuitPlayground.begin();
}

void loop() {
  for (int i=0; i<10; i++) {
    CircuitPlayground.redLED(HIGH);
    delay(200);
    CircuitPlayground.redLED(LOW);
    delay(200);
  }
  CircuitPlayground.playTone(500, 1000);  
}
```