### PR TITLE
Set BURSTMODE reg back after PTC acquire

### DIFF
--- a/utility/Adafruit_CPlay_FreeTouch.cpp
+++ b/utility/Adafruit_CPlay_FreeTouch.cpp
@@ -167,12 +167,19 @@ uint16_t Adafruit_CPlay_FreeTouch::measureRaw(void) {
   setCompCap(compcap);
   setIntCap(intcap);
 
+  uint32_t burstmodeRegBackup = QTOUCH_PTC->BURSTMODE.reg;
+
   QTOUCH_PTC->BURSTMODE.reg = 0xA4;
 
   sync_config();
 
-
-  return startPtcAcquire();
+  uint16_t ptcResult = startPtcAcquire();
+    
+  QTOUCH_PTC->BURSTMODE.reg = burstmodeRegBackup;
+    
+  sync_config();
+    
+  return ptcResult;
 }
 
 uint16_t Adafruit_CPlay_FreeTouch::startPtcAcquire(void) {


### PR DESCRIPTION
This helps solve the interference to analogRead function. And touch seems still working well.

solves: https://github.com/adafruit/Adafruit_CircuitPlayground/issues/55 