### PR TITLE
Implemented IR rawSend in IRsend class

### DIFF
--- a/utility/IRLibCPE.h
+++ b/utility/IRLibCPE.h
@@ -24,6 +24,7 @@
 #include "IRLib_P10_DirecTV.h"
 #include "IRLib_P11_RCMM.h"
 #include "IRLib_P12_CYKM.h"
+#include "IRLib_HashRaw.h"
 //include additional protocols here
 #include "IRLibCombo.h"
 #include "IRLibRecvPCI.h"

--- a/utility/IRLibCombo.h
+++ b/utility/IRLibCombo.h
@@ -29,6 +29,7 @@
 
 #ifndef IRLIB_HASHRAW_H
 	#define IR_SEND_RAW
+	#define IR_SEND_RAW_ALIGNED
 	#define IR_DECODE_HASH
 	#define PV_IR_DECODE_HASH
 	#define PV_IR_SEND_RAW
@@ -245,6 +246,20 @@ public:
 			IR_SEND_RAW	//Must be last one.
 		}
 	}
+	
+	/*
+	* Sends raw IR data.
+	* The first parameter to the method is a pointer to the first element of an array of uint16_t values. 
+	* These values are the raw timing values in microseconds.
+	* The second parameter is the length of the array presented as the first parameter.
+	* If the frequency to be used in transmission is not specified, it defaults to 38kHz.
+	*/
+	#ifdef IRLIB_HASHRAW_H
+		void sendRaw(uint16_t *buf, uint8_t len, uint8_t khz) {
+		if(khz==0)khz=38;
+			IR_SEND_RAW_ALIGNED
+		}
+	#endif //IRLIB_HASHRAW_H
 };
 #endif  //IRLIBSENDBASE_H
 

--- a/utility/IRLib_HashRaw.h
+++ b/utility/IRLib_HashRaw.h
@@ -19,6 +19,7 @@
 #ifndef IRLIB_HASHRAW_H
 #define IRLIB_HASHRAW_H
 #define IR_SEND_RAW		case 0: IRsendRaw::send((uint16_t*)data,data2,khz); break;
+#define IR_SEND_RAW_ALIGNED   IRsendRaw::send(buf,len,khz);
 #define IR_DECODE_HASH	if(IRdecodeHash::decode()) return true;
 #ifdef IRLIB_HAVE_COMBO
 	#define PV_IR_DECODE_HASH ,public virtual IRdecodeHash


### PR DESCRIPTION
Hi!
I noticed there is no implemented support for sending raw IR data.
The relevant function is written in IRLib_HashRaw.h, which had no include statement in IRLibCPE.h, and in addition the only linkage was broken:
The next line is a line is in IRLib_HashRaw.h:
#define IR_SEND_RAW		case 0: IRsendRaw::send((uint16_t*)data,data2,khz); break;

The IR_SEND_RAW macro is used in IRLibCombo.h in IRsend class, in the send method, in order to send raw transmission. That will always result as an illegal cast between uint32_t to uint16_t* .
As a result it's impossible to use this method from the built-in IRsend object in the main object of CircuitPlayground.
IMO the send raw functionality should be separated from the other IR send's functionality as it receives different parameters.
Hope that helps :)
Idan