### PR TITLE
Fix GCC compiler warnings

### DIFF
--- a/utility/IRLibSAMD21.h
+++ b/utility/IRLibSAMD21.h
@@ -68,6 +68,9 @@
 //#define IR_SEND_PWM_PIN 13
 //Override default for Adafruit Circuit Playground Express
 #ifdef ARDUINO_SAMD_CIRCUITPLAYGROUND_EXPRESS
+  #ifdef IR_SEND_PWM_PIN
+    #undef IR_SEND_PWM_PIN
+  #endif
   #define IR_SEND_PWM_PIN 25
 #endif
 //Choose which timer counter to use for the 50 microsecond interrupt

--- a/utility/IRLibSAMD21.h
+++ b/utility/IRLibSAMD21.h
@@ -84,6 +84,13 @@
  * based on the user set values above.
  */
 
+//Clear interrupt
+#ifdef IR_CLEAR_INTERRUPT
+  #undef IR_CLEAR_INTERRUPT
+#endif
+#define IR_CLEAR_INTERRUPT 	IR_TCx->COUNT16.INTFLAG.bit.MC0 = 1;
+
+
 // Saves us a lot of typing when synchronizing
 #define syncTC   while (IR_TCx->COUNT16.STATUS.bit.SYNCBUSY)
 #define syncGCLK while (GCLK->STATUS.bit.SYNCBUSY)
@@ -233,8 +240,6 @@
 #define IR_RECV_DISABLE_INTR  IR_TCx->COUNT16.INTENCLR.reg = TC_INTENCLR_OVF;  
 #define IR_RECV_CONFIG_TICKS() initializeSAMD21timerInterrupt()
 
-//Clear interrupt
-#define IR_CLEAR_INTERRUPT 	IR_TCx->COUNT16.INTFLAG.bit.MC0 = 1;
 
 //prototypes
 void initializeSAMD21PWM(uint16_t khz);


### PR DESCRIPTION
```
In file included from ...\utility\IRLibHardware.h:83,
                 from ...\utility\IRLibHardware.cpp:33:
...\utility\IRLibSAMD21.h:71:
      warning: "IR_SEND_PWM_PIN" redefined
   71 |   #define IR_SEND_PWM_PIN 25
      | 
...\utility\IRLibSAMD21.h:67:
      note: this is the location of the previous definition
   67 | #define IR_SEND_PWM_PIN 12
      | 
```
