### PR TITLE
Fix misleading code formatting & bug

### DIFF
--- a/utility/IRLibDecodeBase.cpp
+++ b/utility/IRLibDecodeBase.cpp
@@ -56,7 +56,9 @@ void IRdecodeBase::dumpResults(bool verbose) {
       Serial.print(i/2-1,DEC);  Serial.print(F(":m"));
     } 
     else {
-       if(interval>0)LowSpace=min(LowSpace, interval);  HiSpace=max (HiSpace, interval);
+       if(interval>0) {
+         LowSpace=min(LowSpace, interval);  HiSpace=max (HiSpace, interval);
+       }
        Serial.print(F(" s"));
     }
     Serial.print(interval, DEC);


### PR DESCRIPTION
GCC properly flags this formatting as misleading.
I think it's also a real bug, and should have the two statements wrapped in curly braces.

However, as I am not familiar enough with this code, requesting review / modification / test to ensure it's the proper fix.


```
...\libraries\Adafruit_CircuitPlayground\utility\IRLibDecodeBase.cpp:
      In member function 'void IRdecodeBase::dumpResults(bool)':
...\libraries\Adafruit_CircuitPlayground\utility\IRLibDecodeBase.cpp:
      Line 59 Char 8
      warning: this 'if' clause does not guard... [-Wmisleading-indentation]
   59 |        if(interval>0)LowSpace=min(LowSpace, interval);  HiSpace=max (HiSpace, interval);
      |        ^~
...\libraries\Adafruit_CircuitPlayground\utility\IRLibDecodeBase.cpp:
      Line 59 Char 57
      note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
   59 |        if(interval>0)LowSpace=min(LowSpace, interval);  HiSpace=max (HiSpace, interval);
      |                                                         ^~~~~~~
```
