### PR TITLE
Avoid unused parameter warning

### DIFF
--- a/utility/IRLibRecvBase.cpp
+++ b/utility/IRLibRecvBase.cpp
@@ -159,6 +159,7 @@ void IRrecvBase::setFrameTimeout(uint16_t frameTimeout) {
  * 2) The buffer overflowed we have to quit. The parameter is for debugging purposes only.
  */
 void IRLib_IRrecvComplete(uint8_t Reason) {
+  (void)Reason;
   // Here we are finished. Let the world know there is new data available.
   recvGlobal.newDataAvailable=true;
   recvGlobal.currentState=STATE_FINISHED;//this essentially pauses the receiver ISR


### PR DESCRIPTION
GCC catches this:

```
...\utility\IRLibRecvBase.cpp:
      In function 'void IRLib_IRrecvComplete(uint8_t)':
...\utility\IRLibRecvBase.cpp:
      Line 161 Char 35
      warning: unused parameter 'Reason' [-Wunused-parameter]
  161 | void IRLib_IRrecvComplete(uint8_t Reason) {
      |                           ~~~~~~~~^~~~~~
```
