### PR TITLE
Fix many uninitialized variable errors

### DIFF
--- a/utility/talkie.cpp
+++ b/utility/talkie.cpp
@@ -87,11 +87,11 @@ void Adafruit_CPlay_Speaker::say(const uint8_t *addr) {
 
 	int16_t  x0=0, x1=0, x2=0, x3=0, x4=0,
 	         x5=0, x6=0, x7=0, x8=0, x9=0,
-	         synthK1, synthK2, u0;
-	uint16_t synthEnergy, synthRand = 1;
-	int8_t   synthK3, synthK4, synthK5, synthK6,
-	         synthK7, synthK8, synthK9, synthK10;
-	uint8_t  periodCounter=0, nextPwm = 0x7F, synthPeriod;
+	         synthK1 = 0, synthK2 = 0, u0;
+	uint16_t synthEnergy = 0, synthRand = 1;
+	int8_t   synthK3 = 0, synthK4 = 0, synthK5 = 0, synthK6 = 0,
+	         synthK7 = 0, synthK8 = 0, synthK9 = 0, synthK10 = 0;
+	uint8_t  periodCounter=0, nextPwm = 0x7F, synthPeriod = 0;
 	uint8_t  iCount = TICKS;
 	uint32_t nowTime, prevTime=0;
 

--- a/utility/talkie.cpp
+++ b/utility/talkie.cpp
@@ -87,12 +87,12 @@ void Adafruit_CPlay_Speaker::say(const uint8_t *addr) {
 
 	int16_t  x0=0, x1=0, x2=0, x3=0, x4=0,
 	         x5=0, x6=0, x7=0, x8=0, x9=0,
-	         synthK1 = 0, synthK2 = 0, u0;
-	uint16_t synthEnergy = 0, synthRand = 1;
-	int8_t   synthK3 = 0, synthK4 = 0, synthK5 = 0, synthK6 = 0,
-	         synthK7 = 0, synthK8 = 0, synthK9 = 0, synthK10 = 0;
-	uint8_t  periodCounter=0, nextPwm = 0x7F, synthPeriod = 0;
-	uint8_t  iCount = TICKS;
+	         synthK1=0, synthK2=0, u0;
+	uint16_t synthEnergy=0, synthRand=1;
+	int8_t   synthK3=0, synthK4=0, synthK5=0, synthK6=0,
+	         synthK7=0, synthK8=0, synthK9=0, synthK10=0;
+	uint8_t  periodCounter=0, nextPwm=0x7F, synthPeriod=0;
+	uint8_t  iCount=TICKS;
 	uint32_t nowTime, prevTime=0;
 
 	if(!started) begin();


### PR DESCRIPTION
Variables are used uninitialized in at least two situations:
1. When first frame is a rest frame (line 115)
2. When first frame is either stop frame or silence (line 117)

It appears that zero-initialization is the correct fix.  Verification is requested.


<details><summary>Compilation warnings</summary><P/>

```
...\utility\talkie.cpp:
      In member function 'void Adafruit_CPlay_Speaker::say(const uint8_t*)':
...\utility\talkie.cpp:
      Line 146 Char 3
      warning: 'synthPeriod' may be used uninitialized in this function [-Wmaybe-uninitialized]
  146 |   if(synthPeriod) { // Voiced source
      |   ^~
...\utility\talkie.cpp:
      Line 155 Char 21
      warning: 'synthK10' may be used uninitialized in this function [-Wmaybe-uninitialized]
  155 |   u0     -=       ((synthK10 *          x9) +
      |                     ^~~~~~~~
...\utility\talkie.cpp:
      Line 156 Char 7
      warning: 'synthK9' may be used uninitialized in this function [-Wmaybe-uninitialized]
  156 |      (synthK9  *          x8)) >>  7;
      |       ^~~~~~~
...\utility\talkie.cpp:
      Line 158 Char 21
      warning: 'synthK8' may be used uninitialized in this function [-Wmaybe-uninitialized]
  158 |   u0     -=       ((synthK8  *          x7 ) >>  7);
      |                     ^~~~~~~
...\utility\talkie.cpp:
      Line 160 Char 21
      warning: 'synthK7' may be used uninitialized in this function [-Wmaybe-uninitialized]
  160 |   u0     -=       ((synthK7  *          x6 ) >>  7);
      |                     ^~~~~~~
...\utility\talkie.cpp:
      Line 162 Char 21
      warning: 'synthK6' may be used uninitialized in this function [-Wmaybe-uninitialized]
  162 |   u0     -=       ((synthK6  *          x5 ) >>  7);
      |                     ^~~~~~~
...\utility\talkie.cpp:
      Line 164 Char 21
      warning: 'synthK5' may be used uninitialized in this function [-Wmaybe-uninitialized]
  164 |   u0     -=       ((synthK5  *          x4 ) >>  7);
      |                     ^~~~~~~
...\utility\talkie.cpp:
      Line 166 Char 21
      warning: 'synthK4' may be used uninitialized in this function [-Wmaybe-uninitialized]
  166 |   u0     -=       ((synthK4  *          x3 ) >>  7);
      |                     ^~~~~~~
...\utility\talkie.cpp:
      Line 168 Char 21
      warning: 'synthK3' may be used uninitialized in this function [-Wmaybe-uninitialized]
  168 |   u0     -=       ((synthK3  *          x2 ) >>  7);
      |                     ^~~~~~~
...\utility\talkie.cpp:
      Line 150 Char 9
      warning: 'synthEnergy' may be used uninitialized in this function [-Wmaybe-uninitialized]
  150 |         (uint32_t)synthEnergy) >> 8;
      |         ^~~~~~~~~~~~~~~~~~~~~
...\utility\talkie.cpp:
      Line 170 Char 21
      warning: 'synthK2' may be used uninitialized in this function [-Wmaybe-uninitialized]
  170 |   u0     -=       ((synthK2  * (int32_t)x1 ) >> 15);
      |                     ^~~~~~~
...\utility\talkie.cpp:
      Line 172 Char 21
      warning: 'synthK1' may be used uninitialized in this function [-Wmaybe-uninitialized]
  172 |   u0     -=       ((synthK1  * (int32_t)x0 ) >> 15);
      |                     ^~~~~~~


...\utility\talkie.cpp:
      In member function 'void Adafruit_CPlay_Speaker::say(const uint8_t*)':
...\utility\talkie.cpp:
      Line 146 Char 3
      warning: 'synthPeriod' may be used uninitialized in this function [-Wmaybe-uninitialized]
  146 |   if(synthPeriod) { // Voiced source
      |   ^~
...\utility\talkie.cpp:
      Line 155 Char 21
      warning: 'synthK10' may be used uninitialized in this function [-Wmaybe-uninitialized]
  155 |   u0     -=       ((synthK10 *          x9) +
      |                     ^~~~~~~~
...\utility\talkie.cpp:
      Line 156 Char 7
      warning: 'synthK9' may be used uninitialized in this function [-Wmaybe-uninitialized]
  156 |      (synthK9  *          x8)) >>  7;
      |       ^~~~~~~
...\utility\talkie.cpp:
      Line 158 Char 21
      warning: 'synthK8' may be used uninitialized in this function [-Wmaybe-uninitialized]
  158 |   u0     -=       ((synthK8  *          x7 ) >>  7);
      |                     ^~~~~~~
...\utility\talkie.cpp:
      Line 160 Char 21
      warning: 'synthK7' may be used uninitialized in this function [-Wmaybe-uninitialized]
  160 |   u0     -=       ((synthK7  *          x6 ) >>  7);
      |                     ^~~~~~~
...\utility\talkie.cpp:
      Line 162 Char 21
      warning: 'synthK6' may be used uninitialized in this function [-Wmaybe-uninitialized]
  162 |   u0     -=       ((synthK6  *          x5 ) >>  7);
      |                     ^~~~~~~
...\utility\talkie.cpp:
      Line 164 Char 21
      warning: 'synthK5' may be used uninitialized in this function [-Wmaybe-uninitialized]
  164 |   u0     -=       ((synthK5  *          x4 ) >>  7);
      |                     ^~~~~~~
...\utility\talkie.cpp:
      Line 166 Char 21
      warning: 'synthK4' may be used uninitialized in this function [-Wmaybe-uninitialized]
  166 |   u0     -=       ((synthK4  *          x3 ) >>  7);
      |                     ^~~~~~~
...\utility\talkie.cpp:
      Line 168 Char 21
      warning: 'synthK3' may be used uninitialized in this function [-Wmaybe-uninitialized]
  168 |   u0     -=       ((synthK3  *          x2 ) >>  7);
      |                     ^~~~~~~
...\utility\talkie.cpp:
      Line 150 Char 9
      warning: 'synthEnergy' may be used uninitialized in this function [-Wmaybe-uninitialized]
  150 |         (uint32_t)synthEnergy) >> 8;
      |         ^~~~~~~~~~~~~~~~~~~~~
...\utility\talkie.cpp:
      Line 170 Char 21
      warning: 'synthK2' may be used uninitialized in this function [-Wmaybe-uninitialized]
  170 |   u0     -=       ((synthK2  * (int32_t)x1 ) >> 15);
      |                     ^~~~~~~
...\utility\talkie.cpp:
      Line 172 Char 21
      warning: 'synthK1' may be used uninitialized in this function [-Wmaybe-uninitialized]
  172 |   u0     -=       ((synthK1  * (int32_t)x0 ) >> 15);
      |                     ^~~~~~~


```
</details>

